### PR TITLE
Create CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+spum.co.uk


### PR DESCRIPTION
CNAME record should allow redirect of the specified domain (spum.co.uk).

Currently, navigating to spum.co.uk in browser does lead to the site, but shows a URL of spumgaming.github.io.
CNAME record should allow this to remain as spum.co.uk